### PR TITLE
Hide read chapters so only unread ones show in a title's chapter list

### DIFF
--- a/reader/desktop/src/lib/chapterListLogic.test.ts
+++ b/reader/desktop/src/lib/chapterListLogic.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect } from 'vitest';
+import type { Chapter, TitleDetailView } from './types';
+import {
+  flattenChapters,
+  buildChapterList,
+  buildOffsets,
+  findRowIndex,
+  visibleRange,
+  rowHeight,
+  ROW_H_FULL,
+  ROW_H_COMPACT,
+  ROW_H_DIVIDER,
+  type ChapterRow,
+} from './chapterListLogic';
+
+function ch(chapterId: number, name = `#${chapterId}`): Chapter {
+  return {
+    titleId: 1,
+    chapterId,
+    name,
+    subTitle: '',
+    thumbnailUrl: '',
+    isUpdated: false,
+  };
+}
+
+const CHAPTERS = [ch(1), ch(2), ch(3), ch(4)];
+
+function chapterIds(rows: ChapterRow[]): number[] {
+  return rows.filter(r => r.type === 'chapter').map(r => r.chapter.chapterId);
+}
+
+describe('flattenChapters', () => {
+  it('prefers chapterListV2', () => {
+    const d = {
+      chapterListV2: [ch(7)],
+      chapterListGroup: {
+        chapterNumbers: '1-10',
+        firstChapterList: [ch(1)],
+        midChapterList: [],
+        lastChapterList: [],
+      },
+    } as unknown as TitleDetailView;
+    expect(flattenChapters(d)).toEqual({ chapters: [ch(7)] });
+  });
+
+  it('falls back to the grouped list and its chapterNumbers divider', () => {
+    const d = {
+      chapterListV2: [],
+      chapterListGroup: {
+        chapterNumbers: '1-10',
+        firstChapterList: [ch(1)],
+        midChapterList: [ch(2)],
+        lastChapterList: [ch(3)],
+      },
+    } as unknown as TitleDetailView;
+    const out = flattenChapters(d);
+    expect(out.chapters.map(c => c.chapterId)).toEqual([1, 2, 3]);
+    expect(out.leadingDivider).toBe('1-10');
+  });
+
+  it('returns an empty list when neither field is present', () => {
+    expect(flattenChapters({ chapterListV2: [] } as unknown as TitleDetailView).chapters).toEqual([]);
+  });
+});
+
+describe('buildChapterList visibility', () => {
+  const readSet = new Set([1, 2]);
+
+  it('"all" keeps every chapter at full height', () => {
+    const b = buildChapterList(CHAPTERS, { sortDesc: false, readSet, visibility: 'all' });
+    expect(chapterIds(b.rows)).toEqual([1, 2, 3, 4]);
+    expect(b.rows.every(r => r.type === 'chapter' && !r.compact)).toBe(true);
+    expect(b.hiddenCount).toBe(0);
+    expect(b.unreadCount).toBe(2);
+    expect(b.totalChapters).toBe(4);
+  });
+
+  it('"compact" keeps read chapters but marks them slim', () => {
+    const b = buildChapterList(CHAPTERS, { sortDesc: false, readSet, visibility: 'compact' });
+    expect(chapterIds(b.rows)).toEqual([1, 2, 3, 4]);
+    const compacted = b.rows.flatMap(r =>
+      r.type === 'chapter' && r.compact ? [r.chapter.chapterId] : [],
+    );
+    expect(compacted).toEqual([1, 2]);
+    expect(b.hiddenCount).toBe(0);
+  });
+
+  it('"hidden" drops read chapters entirely', () => {
+    const b = buildChapterList(CHAPTERS, { sortDesc: false, readSet, visibility: 'hidden' });
+    expect(chapterIds(b.rows)).toEqual([3, 4]);
+    expect(b.hiddenCount).toBe(2);
+    expect(b.unreadCount).toBe(2);
+    expect(b.totalChapters).toBe(4);
+  });
+
+  it('hides everything when all chapters are read', () => {
+    const b = buildChapterList(CHAPTERS, {
+      sortDesc: false,
+      readSet: new Set([1, 2, 3, 4]),
+      visibility: 'hidden',
+    });
+    expect(chapterIds(b.rows)).toEqual([]);
+    expect(b.unreadCount).toBe(0);
+    expect(b.hiddenCount).toBe(4);
+  });
+
+  it('reverses for descending sort without mutating the input', () => {
+    const input = [...CHAPTERS];
+    const b = buildChapterList(input, { sortDesc: true, readSet: new Set(), visibility: 'all' });
+    expect(chapterIds(b.rows)).toEqual([4, 3, 2, 1]);
+    expect(input.map(c => c.chapterId)).toEqual([1, 2, 3, 4]);
+  });
+
+  it('keeps the leading divider even when every chapter under it is hidden', () => {
+    const b = buildChapterList(CHAPTERS, {
+      sortDesc: false,
+      readSet: new Set([1, 2, 3, 4]),
+      visibility: 'hidden',
+      leadingDivider: '1-4',
+    });
+    expect(b.rows).toEqual([{ type: 'divider', label: '1-4' }]);
+  });
+});
+
+describe('row geometry', () => {
+  it('sizes rows by kind', () => {
+    expect(rowHeight({ type: 'divider', label: 'x' })).toBe(ROW_H_DIVIDER);
+    expect(rowHeight({ type: 'chapter', chapter: ch(1), read: false, compact: false })).toBe(ROW_H_FULL);
+    expect(rowHeight({ type: 'chapter', chapter: ch(1), read: true, compact: true })).toBe(ROW_H_COMPACT);
+  });
+
+  it('builds prefix sums ending at the total height', () => {
+    const rows: ChapterRow[] = [
+      { type: 'divider', label: 'x' },
+      { type: 'chapter', chapter: ch(1), read: true, compact: true },
+      { type: 'chapter', chapter: ch(2), read: false, compact: false },
+    ];
+    const offsets = buildOffsets(rows);
+    expect(offsets).toEqual([
+      0,
+      ROW_H_DIVIDER,
+      ROW_H_DIVIDER + ROW_H_COMPACT,
+      ROW_H_DIVIDER + ROW_H_COMPACT + ROW_H_FULL,
+    ]);
+  });
+
+  it('offsets an empty list to a zero-height table', () => {
+    expect(buildOffsets([])).toEqual([0]);
+    expect(visibleRange(buildOffsets([]), 0, 800)).toEqual({ start: 0, end: 0 });
+  });
+});
+
+describe('findRowIndex / visibleRange', () => {
+  // 10 full rows: boundaries at 0, 72, 144, …
+  const rows: ChapterRow[] = Array.from({ length: 10 }, (_, i) => ({
+    type: 'chapter' as const,
+    chapter: ch(i + 1),
+    read: false,
+    compact: false,
+  }));
+  const offsets = buildOffsets(rows);
+
+  it('finds the row containing a scroll position', () => {
+    expect(findRowIndex(offsets, 0)).toBe(0);
+    expect(findRowIndex(offsets, ROW_H_FULL - 1)).toBe(0);
+    expect(findRowIndex(offsets, ROW_H_FULL)).toBe(1);
+    expect(findRowIndex(offsets, ROW_H_FULL * 3 + 5)).toBe(3);
+  });
+
+  it('clamps negative and past-the-end positions', () => {
+    expect(findRowIndex(offsets, -50)).toBe(0);
+    expect(findRowIndex(offsets, 99999)).toBe(rows.length - 1);
+  });
+
+  it('covers the viewport plus overscan, clamped to the list', () => {
+    const { start, end } = visibleRange(offsets, ROW_H_FULL * 4, ROW_H_FULL * 2, 1);
+    expect(start).toBe(3);
+    expect(end).toBe(8); // rows 4..6 visible, +1 overscan each side
+  });
+
+  it('never returns a window outside the row list', () => {
+    const top = visibleRange(offsets, 0, ROW_H_FULL * 3, 10);
+    expect(top.start).toBe(0);
+    expect(top.end).toBe(rows.length);
+    const bottom = visibleRange(offsets, ROW_H_FULL * 100, ROW_H_FULL * 3, 10);
+    expect(bottom.end).toBe(rows.length);
+    expect(bottom.start).toBeGreaterThanOrEqual(0);
+  });
+
+  it('handles mixed heights — a compact run is denser per pixel', () => {
+    const mixed: ChapterRow[] = [
+      { type: 'chapter', chapter: ch(1), read: true, compact: true },
+      { type: 'chapter', chapter: ch(2), read: true, compact: true },
+      { type: 'chapter', chapter: ch(3), read: false, compact: false },
+    ];
+    const off = buildOffsets(mixed);
+    expect(findRowIndex(off, ROW_H_COMPACT)).toBe(1);
+    expect(findRowIndex(off, ROW_H_COMPACT * 2)).toBe(2);
+  });
+});

--- a/reader/desktop/src/lib/chapterListLogic.ts
+++ b/reader/desktop/src/lib/chapterListLogic.ts
@@ -1,0 +1,152 @@
+// Pure logic for the title page's chapter list. Extracted from
+// `routes/title/[id]/+page.svelte` so row building, read-filtering and
+// the variable-height virtualization math are unit-testable without a
+// Svelte/Tauri harness. Mirrors the pattern from `lib/readerLogic.ts`:
+// no $state, no DOM, no localStorage in here.
+
+import type { Chapter, TitleDetailView } from './types';
+import type { ReadVisibility } from './readState';
+
+/** One rendered row in the virtual chapter list. */
+export type ChapterRow =
+  | { type: 'chapter'; chapter: Chapter; read: boolean; compact: boolean }
+  | { type: 'divider'; label: string };
+
+/** Row heights, in px. The virtualizer needs these up front — rows are
+ *  absolutely positioned, so declared height must match rendered height
+ *  (see the matching CSS in the title page). */
+export const ROW_H_FULL = 72;
+export const ROW_H_COMPACT = 34;
+export const ROW_H_DIVIDER = 72;
+
+export function rowHeight(row: ChapterRow): number {
+  if (row.type === 'divider') return ROW_H_DIVIDER;
+  return row.compact ? ROW_H_COMPACT : ROW_H_FULL;
+}
+
+/**
+ * Flatten a TitleDetailView into the server's ascending chapter order.
+ * `chapterListV2` is the modern field; older responses only carry
+ * `chapterListGroup`, whose `chapterNumbers` string becomes a leading
+ * divider label.
+ */
+export function flattenChapters(d: TitleDetailView): {
+  chapters: Chapter[];
+  leadingDivider?: string;
+} {
+  if (d.chapterListV2 && d.chapterListV2.length > 0) {
+    return { chapters: [...d.chapterListV2] };
+  }
+  const grp = d.chapterListGroup;
+  if (!grp) return { chapters: [] };
+  return {
+    chapters: [...grp.firstChapterList, ...grp.midChapterList, ...grp.lastChapterList],
+    leadingDivider: grp.chapterNumbers || undefined,
+  };
+}
+
+export type ChapterListOptions = {
+  /** Newest-first when true (the server sends oldest-first). */
+  sortDesc: boolean;
+  readSet: ReadonlySet<number>;
+  /** How already-read chapters are presented. */
+  visibility: ReadVisibility;
+  leadingDivider?: string;
+};
+
+export type BuiltChapterList = {
+  rows: ChapterRow[];
+  /** Prefix sums of row heights; length is rows.length + 1, so
+   *  `offsets[i]` is the top of row i and the last entry is the total
+   *  scroll height. */
+  offsets: number[];
+  totalChapters: number;
+  unreadCount: number;
+  /** Chapters omitted from `rows` because they're read and the
+   *  visibility mode is 'hidden'. */
+  hiddenCount: number;
+};
+
+/**
+ * Build the flat row list plus its virtualization offsets.
+ *
+ *   'all'     — every chapter at full height (the original behaviour)
+ *   'compact' — read chapters collapse to a slim one-line row
+ *   'hidden'  — read chapters are dropped entirely; only unread remain
+ *
+ * The leading divider survives filtering: it labels the whole list, not
+ * a chapter, so it's kept even when every chapter under it is hidden.
+ */
+export function buildChapterList(
+  chapters: Chapter[],
+  opts: ChapterListOptions,
+): BuiltChapterList {
+  const ordered = opts.sortDesc ? [...chapters].reverse() : [...chapters];
+
+  const rows: ChapterRow[] = [];
+  if (opts.leadingDivider) rows.push({ type: 'divider', label: opts.leadingDivider });
+
+  let unreadCount = 0;
+  let hiddenCount = 0;
+  for (const chapter of ordered) {
+    const read = opts.readSet.has(chapter.chapterId);
+    if (!read) unreadCount++;
+    if (read && opts.visibility === 'hidden') {
+      hiddenCount++;
+      continue;
+    }
+    rows.push({ type: 'chapter', chapter, read, compact: read && opts.visibility === 'compact' });
+  }
+
+  const offsets = buildOffsets(rows);
+  return { rows, offsets, totalChapters: ordered.length, unreadCount, hiddenCount };
+}
+
+/** Prefix sums of row heights. `offsets[rows.length]` is the total height. */
+export function buildOffsets(rows: ChapterRow[]): number[] {
+  const offsets = new Array<number>(rows.length + 1);
+  offsets[0] = 0;
+  for (let i = 0; i < rows.length; i++) offsets[i + 1] = offsets[i] + rowHeight(rows[i]);
+  return offsets;
+}
+
+/** Index of the row containing `y` — the largest i with offsets[i] <= y. */
+export function findRowIndex(offsets: number[], y: number): number {
+  const n = offsets.length - 1;
+  if (n <= 0) return 0;
+  const target = Math.max(0, y);
+  let lo = 0;
+  let hi = n - 1;
+  let ans = 0;
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1;
+    if (offsets[mid] <= target) {
+      ans = mid;
+      lo = mid + 1;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  return ans;
+}
+
+/**
+ * Half-open [start, end) row window covering the viewport, padded by
+ * `overscan` rows on each side. Rows have variable heights, so this
+ * binary-searches the offset table instead of dividing by a constant.
+ */
+export function visibleRange(
+  offsets: number[],
+  scrollTop: number,
+  viewportHeight: number,
+  overscan = 10,
+): { start: number; end: number } {
+  const n = offsets.length - 1;
+  if (n <= 0) return { start: 0, end: 0 };
+  const first = findRowIndex(offsets, scrollTop);
+  const last = findRowIndex(offsets, scrollTop + Math.max(0, viewportHeight));
+  return {
+    start: Math.max(0, first - overscan),
+    end: Math.min(n, last + 1 + overscan),
+  };
+}

--- a/reader/desktop/src/lib/readState.test.ts
+++ b/reader/desktop/src/lib/readState.test.ts
@@ -6,6 +6,9 @@ import {
   getLastReadChapter,
   getSortDescending,
   setSortDescending,
+  getReadVisibility,
+  setReadVisibility,
+  nextReadVisibility,
   getPageMode,
   setPageMode,
   getPageModeForTitle,
@@ -179,5 +182,26 @@ describe('readState', () => {
     expect(getHelpSeen()).toBe(true);
     setHelpSeen(false);
     expect(getHelpSeen()).toBe(false);
+  });
+});
+
+describe('readVisibility', () => {
+  it('defaults to hiding read chapters', () => {
+    expect(getReadVisibility()).toBe('hidden');
+  });
+
+  it('round-trips a stored mode and ignores junk', () => {
+    setReadVisibility('compact');
+    expect(getReadVisibility()).toBe('compact');
+    setReadVisibility('all');
+    expect(getReadVisibility()).toBe('all');
+    localStorage.setItem('mp:readVis', 'nonsense');
+    expect(getReadVisibility()).toBe('hidden');
+  });
+
+  it('cycles hidden → compact → all → hidden', () => {
+    expect(nextReadVisibility('hidden')).toBe('compact');
+    expect(nextReadVisibility('compact')).toBe('all');
+    expect(nextReadVisibility('all')).toBe('hidden');
   });
 });

--- a/reader/desktop/src/lib/readState.ts
+++ b/reader/desktop/src/lib/readState.ts
@@ -86,6 +86,28 @@ export function setSortDescending(v: boolean) {
   localStorage.setItem(KEY_SORT_DESC, v ? '1' : '0');
 }
 
+// How already-read chapters are presented in a title's chapter list.
+//   - "hidden"  — read chapters are omitted; only unread ones show (default)
+//   - "compact" — read chapters collapse to a slim one-line row
+//   - "all"     — every chapter at full height
+// One global flag, like the sort order: readers who want unread-only
+// want it for every title, not per title.
+export type ReadVisibility = 'hidden' | 'compact' | 'all';
+const KEY_READ_VIS = 'mp:readVis';
+const READ_VIS_VALUES: ReadVisibility[] = ['hidden', 'compact', 'all'];
+export function getReadVisibility(): ReadVisibility {
+  const v = localStorage.getItem(KEY_READ_VIS);
+  return (READ_VIS_VALUES as string[]).includes(v ?? '') ? (v as ReadVisibility) : 'hidden';
+}
+export function setReadVisibility(v: ReadVisibility) {
+  localStorage.setItem(KEY_READ_VIS, v);
+}
+// Cycle order driven by the toggle button: hidden → compact → all → hidden.
+export function nextReadVisibility(v: ReadVisibility): ReadVisibility {
+  const i = READ_VIS_VALUES.indexOf(v);
+  return READ_VIS_VALUES[(i + 1) % READ_VIS_VALUES.length];
+}
+
 // Reader page layout.
 //   - "single"       — one page per frame, the default
 //   - "double"       — sequential pairs starting from page 1: [1,2],[3,4],…

--- a/reader/desktop/src/routes/title/[id]/+page.svelte
+++ b/reader/desktop/src/routes/title/[id]/+page.svelte
@@ -2,13 +2,23 @@
   import { onMount } from 'svelte';
   import { page } from '$app/stores';
   import { goto } from '$app/navigation';
-  import type { TitleDetailView, Chapter } from '$lib/types';
+  import type { TitleDetailView } from '$lib/types';
   import {
     getReadChapters,
     getLastReadChapter,
     getSortDescending,
     setSortDescending,
+    getReadVisibility,
+    setReadVisibility,
+    nextReadVisibility,
+    type ReadVisibility,
   } from '$lib/readState';
+  import {
+    flattenChapters,
+    buildChapterList,
+    visibleRange,
+    type ChapterRow,
+  } from '$lib/chapterListLogic';
   import { proxied } from '$lib/img';
   import { DEFAULT_LANG, DEFAULT_CLANG, DEFAULT_COUNTRY } from '$lib/lang';
   import { withIpcTimeout } from '$lib/ipcTimeout';
@@ -30,18 +40,24 @@
   let favPending = $state(false);
   let favError = $state('');
   let sortDesc = $state(true);
+  let readVis: ReadVisibility = $state('hidden');
   let readSet: Set<number> = $state(new Set());
   let lastReadId: number | null = $state(null);
 
   // Flattened chapter list for rendering
-  type ChapterRow = { type: 'chapter'; chapter: Chapter } | { type: 'divider'; label: string };
   let rows: ChapterRow[] = $state([]);
+  // Prefix sums of row heights — rows vary in height (a read chapter in
+  // "compact" mode is a slim line), so the virtualizer indexes this
+  // table instead of multiplying by a constant.
+  let rowOffsets: number[] = $state([0]);
+  let totalChapters = $state(0);
+  let unreadCount = $state(0);
+  let hiddenCount = $state(0);
 
   // Virtualization state
   let listContainer: HTMLElement | undefined = $state(undefined);
   let visibleStart = $state(0);
   let visibleEnd = $state(50);
-  const ITEM_HEIGHT = 72; // approximate px per row
   const OVERSCAN = 10;
 
   let bannerCss = $derived.by(() => {
@@ -49,8 +65,8 @@
     return bg ? 'url(' + proxied(bg) + ')' : 'none';
   });
 
-  let totalHeight = $derived(rows.length * ITEM_HEIGHT);
-  let offsetTop = $derived(visibleStart * ITEM_HEIGHT);
+  let totalHeight = $derived(rowOffsets[rowOffsets.length - 1] ?? 0);
+  let offsetTop = $derived(rowOffsets[visibleStart] ?? 0);
   let visibleRows = $derived(rows.slice(visibleStart, visibleEnd));
   type StyleMap = Record<string, string>;
   let bannerStyles = $derived({ 'background-image': bannerCss });
@@ -81,6 +97,7 @@
 
   onMount(() => {
     sortDesc = getSortDescending();
+    readVis = getReadVisibility();
   });
 
   $effect(() => {
@@ -101,12 +118,17 @@
     void loadDetail(id, activeLang, activeClang, activeCountry, seq);
   });
 
-  // Reload read-state and rows whenever titleId / sortDesc change.
+  // Reload read-state and rows whenever titleId / sortDesc / read
+  // visibility change. `reads` is passed into buildRows rather than read
+  // back off `readSet`: this effect *writes* readSet, and an effect that
+  // also reads what it writes re-triggers itself forever
+  // ("effect_update_depth_exceeded").
   $effect(() => {
     if (detail) {
-      readSet = getReadChapters(titleId);
+      const reads = getReadChapters(titleId);
+      readSet = reads;
       lastReadId = getLastReadChapter(titleId);
-      buildRows(detail);
+      buildRows(detail, reads);
     }
   });
 
@@ -131,9 +153,10 @@
       }));
       if (seq !== loadSeq) return;
       detail = d;
-      readSet = getReadChapters(id);
+      const reads = getReadChapters(id);
+      readSet = reads;
       lastReadId = getLastReadChapter(id);
-      buildRows(d);
+      buildRows(d, reads);
       loading = false;
 
       void loadFavoriteState(id, seq);
@@ -158,44 +181,62 @@
     }
   }
 
-  function buildRows(d: TitleDetailView) {
-    let chapters: Chapter[] = [];
-    let dividers: { afterIndex: number; label: string }[] = [];
+  function buildRows(d: TitleDetailView, reads: ReadonlySet<number>, resetScroll = true) {
+    const { chapters, leadingDivider } = flattenChapters(d);
+    const built = buildChapterList(chapters, {
+      sortDesc,
+      readSet: reads,
+      visibility: readVis,
+      leadingDivider,
+    });
 
-    if (d.chapterListV2 && d.chapterListV2.length > 0) {
-      chapters = [...d.chapterListV2];
-    } else if (d.chapterListGroup) {
-      const grp = d.chapterListGroup;
-      chapters = [
-        ...grp.firstChapterList,
-        ...grp.midChapterList,
-        ...grp.lastChapterList,
-      ];
-      if (grp.chapterNumbers) {
-        dividers.push({ afterIndex: -1, label: grp.chapterNumbers });
-      }
-    }
-
-    // Server returns ascending (oldest → newest). Reverse for descending.
-    if (sortDesc) chapters.reverse();
-
-    const built: ChapterRow[] = [];
-    for (const div of dividers) if (div.afterIndex === -1) built.push({ type: 'divider', label: div.label });
-    for (const ch of chapters) built.push({ type: 'chapter', chapter: ch });
-
-    // Important: use built.length (not rows.length) here. Reading rows
-    // right after writing it inside the $effect → infinite reactive loop
-    // ("effect_update_depth_exceeded"). Same value, different dep graph.
-    rows = built;
-    visibleEnd = Math.min(50, built.length);
-    if (listContainer) listContainer.scrollTop = 0;
+    // Important: read from `built` (not the rows/rowOffsets state) here.
+    // Reading state right after writing it inside the $effect →
+    // infinite reactive loop ("effect_update_depth_exceeded"). Same
+    // values, different dep graph.
+    rows = built.rows;
+    rowOffsets = built.offsets;
+    totalChapters = built.totalChapters;
+    unreadCount = built.unreadCount;
+    hiddenCount = built.hiddenCount;
+    visibleStart = 0;
+    visibleEnd = Math.min(50, built.rows.length);
+    if (resetScroll && listContainer) listContainer.scrollTop = 0;
   }
 
   function toggleSort() {
     sortDesc = !sortDesc;
     setSortDescending(sortDesc);
-    if (detail) buildRows(detail);
+    if (detail) buildRows(detail, readSet);
   }
+
+  // Cycle: hidden → compact → all. Read chapters are hidden by default
+  // so opening a title shows what's left to read; the other two modes
+  // bring them back (slim, then full) for re-reading.
+  function cycleReadVisibility() {
+    readVis = nextReadVisibility(readVis);
+    setReadVisibility(readVis);
+    if (detail) buildRows(detail, readSet);
+  }
+
+  function showAllChapters() {
+    if (readVis === 'all') return;
+    readVis = 'all';
+    setReadVisibility(readVis);
+    if (detail) buildRows(detail, readSet);
+  }
+
+  let readVisLabel = $derived(
+    readVis === 'hidden' ? '\u25CF Unread only'
+      : readVis === 'compact' ? '\u25D0 Read collapsed'
+      : '\u25CB All chapters',
+  );
+  let readVisHint = $derived(
+    readVis === 'hidden'
+      ? `${hiddenCount} read chapter${hiddenCount === 1 ? '' : 's'} hidden \u2014 click to collapse them instead`
+      : readVis === 'compact' ? 'Read chapters are collapsed \u2014 click to show them in full'
+      : 'All chapters shown \u2014 click to hide read ones',
+  );
 
   function openChapter(chapterId: number, e?: MouseEvent) {
     if (e) {
@@ -215,10 +256,7 @@
 
   function onScroll(e: Event) {
     const el = e.target as HTMLElement;
-    const scrollTop = el.scrollTop;
-    const viewportH = el.clientHeight;
-    const start = Math.max(0, Math.floor(scrollTop / ITEM_HEIGHT) - OVERSCAN);
-    const end = Math.min(rows.length, Math.ceil((scrollTop + viewportH) / ITEM_HEIGHT) + OVERSCAN);
+    const { start, end } = visibleRange(rowOffsets, el.scrollTop, el.clientHeight, OVERSCAN);
     visibleStart = start;
     visibleEnd = end;
   }
@@ -304,18 +342,35 @@
       <!-- Right column: virtual chapter list -->
       <section class="chapter-section">
         <div class="chapter-header">
-          <h2 class="section-heading">Chapters ({rows.filter(r => r.type === 'chapter').length})</h2>
+          <h2 class="section-heading">
+            Chapters
+            {#if totalChapters > 0}
+              ({unreadCount} unread of {totalChapters})
+            {/if}
+          </h2>
           <div class="chapter-actions">
             {#if lastReadId != null}
               <a class="continue-link" href="/reader/{lastReadId}{readerSuffix}">Continue ▶</a>
             {/if}
+            <button
+              class="sort-btn"
+              onclick={cycleReadVisibility}
+              title={readVisHint}
+            >
+              {readVisLabel}
+            </button>
             <button class="sort-btn" onclick={toggleSort} title="Toggle sort order">
               {sortDesc ? '↓ Newest first' : '↑ Oldest first'}
             </button>
           </div>
         </div>
-        {#if rows.length === 0}
+        {#if totalChapters === 0}
           <p class="no-chapters">No chapters available.</p>
+        {:else if unreadCount === 0 && readVis === 'hidden'}
+          <p class="no-chapters">
+            All {totalChapters} chapters read — nothing new here.
+            <button class="link-btn" onclick={showAllChapters}>Show all chapters</button>
+          </p>
         {:else}
           <div
             class="chapter-scroll"
@@ -332,24 +387,28 @@
                     {@const ch = row.chapter}
                     <a
                       class="chapter-row"
-                      class:is-read={readSet.has(ch.chapterId)}
+                      class:is-read={row.read}
+                      class:is-compact={row.compact}
                       class:is-last-read={ch.chapterId === lastReadId}
                       href="/reader/{ch.chapterId}{readerSuffix}"
                       onclick={(e) => openChapter(ch.chapterId, e)}
                     >
                       <div class="chapter-meta">
                         <span class="chapter-name">{ch.name}</span>
-                        {#if ch.isUpdated}
+                        {#if row.compact && ch.subTitle}
+                          <span class="chapter-subtitle inline">{ch.subTitle}</span>
+                        {/if}
+                        {#if ch.isUpdated && !row.read}
                           <span class="badge badge-new">New</span>
                         {/if}
-                        {#if readSet.has(ch.chapterId)}
+                        {#if row.read && !row.compact}
                           <span class="badge badge-read">Read</span>
                         {/if}
                         {#if ch.chapterId === lastReadId}
                           <span class="badge badge-last">Last opened</span>
                         {/if}
                       </div>
-                      {#if ch.subTitle}
+                      {#if ch.subTitle && !row.compact}
                         <span class="chapter-subtitle">{ch.subTitle}</span>
                       {/if}
                     </a>
@@ -524,6 +583,7 @@
     color: var(--text-muted);
     background: var(--bg-elevated);
     border-bottom: 1px solid var(--border);
+    /* Matches ROW_H_DIVIDER in lib/chapterListLogic.ts. */
     height: 72px;
     display: flex;
     align-items: center;
@@ -535,7 +595,11 @@
     justify-content: center;
     padding: 10px 14px;
     border-bottom: 1px solid var(--border);
-    min-height: 72px;
+    /* Fixed, not min-height: the virtualizer positions the visible
+       window from a height table (lib/chapterListLogic.ts, ROW_H_FULL),
+       so a row that grows would drift out of sync with the spacer. */
+    height: 72px;
+    overflow: hidden;
     transition: background 0.12s;
     cursor: pointer;
   }
@@ -609,6 +673,53 @@
   .chapter-row.is-read .chapter-name,
   .chapter-row.is-read .chapter-subtitle {
     color: var(--text-muted);
+  }
+
+  /* "Read collapsed" mode: a read chapter shrinks to a single slim line
+     so finished chapters stay reachable without pushing unread ones off
+     screen. The height here must match ROW_H_COMPACT in
+     lib/chapterListLogic.ts — the virtualizer positions rows absolutely
+     from those numbers. */
+  .chapter-row.is-compact {
+    flex-direction: row;
+    align-items: center;
+    height: 34px;
+    padding: 0 14px;
+    opacity: 0.62;
+  }
+
+  .chapter-row.is-compact .chapter-meta {
+    flex-wrap: nowrap;
+    overflow: hidden;
+    width: 100%;
+  }
+
+  .chapter-row.is-compact .chapter-name {
+    font-size: 0.8rem;
+    font-weight: 500;
+    white-space: nowrap;
+  }
+
+  .chapter-row.is-compact:hover {
+    opacity: 1;
+  }
+
+  .chapter-subtitle.inline {
+    margin-top: 0;
+    font-size: 0.75rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .link-btn {
+    background: none;
+    border: none;
+    color: var(--accent);
+    font-size: inherit;
+    padding: 0 0 0 4px;
+    cursor: pointer;
+    text-decoration: underline;
   }
 
   .chapter-row.is-last-read {


### PR DESCRIPTION
## Problem

Opening a title shows every chapter it has ever published, newest first. For a long-running series the chapters you actually have left to read are buried under hundreds you have already finished, and the only signal distinguishing them is a muted text colour.

## What this does

Read chapters are hidden by default, with a toggle next to the sort button cycling through three modes:

- **● Unread only** (default) — read chapters are omitted
- **◐ Read collapsed** — read chapters shrink to a slim 34px line, still clickable for re-reads
- **○ All chapters** — the previous behaviour

The choice persists in `localStorage` under `mp:readVis`, alongside the existing `mp:sortDesc` sort preference. The heading becomes `Chapters (12 unread of 130)`.

**This changes default behaviour**, deliberately: the point is that opening a title shows what is left to read without any first-run configuration. One click on the toggle restores the old view permanently.

## Implementation notes

Row building, read-filtering and the virtualization maths move into a new pure `lib/chapterListLogic.ts`, mirroring the existing `lib/readerLogic.ts` convention, so they are unit-testable without a Svelte or Tauri harness. The route component stays a wiring layer.

Rows are no longer a uniform height, which the old virtualizer assumed (`ITEM_HEIGHT = 72`, `scrollTop / ITEM_HEIGHT`). A compact read row is 34px, so the virtualizer now binary-searches a prefix-sum height table instead of dividing by a constant.

`.chapter-row` also changes from `min-height: 72px` to a fixed `height`. Rows are positioned absolutely from the declared heights, so a row that grew past its declared height would drift out of sync with the spacer — latent before, reachable once heights vary.

When every chapter has been read the list is replaced by a count plus a "Show all chapters" link, so the mode can never strand the user with an empty list and no way out.

## Tests

20 new tests (`chapterListLogic.test.ts`, plus read-visibility cases in `readState.test.ts`) covering the three visibility modes, the all-read case, sort interaction, divider retention, and the offset/binary-search geometry including mixed row heights.

`bun run test` 97 passed · `bun run check` 0 errors.
