### PR TITLE
Fix the reader's broken-image Reload button never refetching

### DIFF
--- a/reader/api/src/client.rs
+++ b/reader/api/src/client.rs
@@ -63,6 +63,26 @@ pub const DEFAULT_IMAGE_RETRY_BACKOFF_MS: u64 = 250;
 /// breathing room.
 pub const MAX_IMAGE_BYTES: u64 = 32 * 1024 * 1024;
 
+/// How long an idle pooled connection may be reused. Deliberately
+/// short: after the machine suspends (lid closed) or sits idle, every
+/// pooled TCP connection is dead, but the local kernel does not know
+/// it — reusing one means writing a request into a socket that will
+/// never answer. Expiring idle connections aggressively means we dial
+/// fresh after a resume instead.
+const POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Ceiling on a single request, connect included. Without this a dead
+/// pooled connection hangs until the OS TCP timeout (~15 min). That is
+/// worse than it sounds: a hung image fetch holds an `image_gate`
+/// permit the whole time, and once all permits are parked, every later
+/// fetch — including a user's retry — blocks before it can even start.
+/// A hang is also not an error, so `fetch_image`'s retry loop never
+/// runs. Generous enough for a large page on a slow link.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Ceiling on connection establishment alone.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
+
 /// Cap on the exponential shift in [`backoff_delay_ms`]. A shift of 8
 /// means base × 256, so with the default 250 ms base the longest
 /// single retry sleep is ~64 s — long enough to ride out a brief CDN
@@ -155,6 +175,12 @@ impl Client {
         let http = reqwest::Client::builder()
             .user_agent("okhttp/4.12.0")
             .cookie_store(true)
+            // See the constants: no timeout at all means a
+            // suspend-stalled connection parks an image_gate permit
+            // indefinitely and the reader never recovers.
+            .pool_idle_timeout(POOL_IDLE_TIMEOUT)
+            .connect_timeout(CONNECT_TIMEOUT)
+            .timeout(REQUEST_TIMEOUT)
             .build()?;
         // Cap the semaphore at the configured concurrency. Zero would
         // be a deadlock; floor it at 1 to be safe.

--- a/reader/desktop/src-tauri/src/lib.rs
+++ b/reader/desktop/src-tauri/src/lib.rs
@@ -175,11 +175,78 @@ fn resolve_secret(env_val: Option<&str>, path: &std::path::Path) -> String {
     String::new()
 }
 
+/// Query parameter the reader appends to bust a failed image load.
+/// Must match `RETRY_PARAM` in `src/lib/readerLogic.ts`.
+const RETRY_PARAM: &str = "mpretry";
+
+/// Strip the reader's cache-busting retry parameter from a CDN URL.
+///
+/// The reader needs the `<img>` src to change so WebKit treats a retry
+/// as a new resource, but the CDN checks a signed query string — so the
+/// parameter has to come back off before the URL leaves this process.
+/// A fragment would avoid that, but fragments never reach a URL loader
+/// and are excluded from WebKit's cache key, so they cannot force a
+/// refetch in the first place.
+fn strip_retry_param(url: &str) -> String {
+    let Some((base, query)) = url.split_once('?') else {
+        return url.to_string();
+    };
+    let kept: Vec<&str> = query
+        .split('&')
+        .filter(|p| {
+            let name = p.split_once('=').map(|(k, _)| k).unwrap_or(p);
+            name != RETRY_PARAM
+        })
+        .collect();
+    if kept.is_empty() {
+        base.to_string()
+    } else {
+        format!("{base}?{}", kept.join("&"))
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{filter_to_language, lang_str_to_enum, merge_views, resolve_secret};
+    use super::{
+        filter_to_language, lang_str_to_enum, merge_views, resolve_secret, strip_retry_param,
+    };
     use mangaplus_api::proto;
     use std::io::Write;
+
+    #[test]
+    fn strip_retry_param_removes_only_the_retry_key() {
+        // Signed query preserved verbatim; only mpretry comes off.
+        assert_eq!(
+            strip_retry_param("https://cdn/a/1.webp?hash=abc&mpretry=2"),
+            "https://cdn/a/1.webp?hash=abc"
+        );
+        // Retry param first in the query.
+        assert_eq!(
+            strip_retry_param("https://cdn/a/1.webp?mpretry=2&hash=abc"),
+            "https://cdn/a/1.webp?hash=abc"
+        );
+        // Sole param: the "?" goes too, so the URL matches the
+        // un-retried form byte for byte.
+        assert_eq!(
+            strip_retry_param("https://cdn/a/1.webp?mpretry=1"),
+            "https://cdn/a/1.webp"
+        );
+    }
+
+    #[test]
+    fn strip_retry_param_leaves_untouched_urls_alone() {
+        assert_eq!(
+            strip_retry_param("https://cdn/a/1.webp?hash=abc"),
+            "https://cdn/a/1.webp?hash=abc"
+        );
+        assert_eq!(strip_retry_param("https://cdn/a/1.webp"), "https://cdn/a/1.webp");
+        // A param that merely starts with the same letters is not the
+        // retry param and must survive.
+        assert_eq!(
+            strip_retry_param("https://cdn/a/1.webp?mpretryx=9"),
+            "https://cdn/a/1.webp?mpretryx=9"
+        );
+    }
 
     fn title(id: u32, name: &str, language: i32) -> proto::Title {
         proto::Title {
@@ -957,7 +1024,9 @@ pub fn run() {
         // Frontend usage: replace the `https://` of imageUrl with `mpimg://`.
         .register_asynchronous_uri_scheme_protocol("mpimg", move |_ctx, request, responder| {
             let url = request.uri().to_string();
-            let https_url = url.replacen("mpimg://", "https://", 1);
+            // Drop the reader's retry cache-buster before the URL goes
+            // to the CDN — it is not part of the signed query.
+            let https_url = strip_retry_param(&url.replacen("mpimg://", "https://", 1));
             let client = scheme_state_for_handler
                 .lock()
                 .map(|g| g.clone())

--- a/reader/desktop/src/lib/readerLogic.test.ts
+++ b/reader/desktop/src/lib/readerLogic.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
+  retryImageSrc,
+  RETRY_PARAM,
   buildPageGroups,
   scanChapterBounds,
   chapterIdAfter,
@@ -268,5 +270,39 @@ describe('keyToReaderAction', () => {
     expect(keyToReaderAction('Tab')).toBe(null);
     // Case sensitivity: only 'd'/'D' are mapped, not other casings.
     expect(keyToReaderAction('e')).toBe(null);
+  });
+});
+
+describe('retryImageSrc', () => {
+  const signed = 'mpimg://cdn.example/secure/1.webp?hash=abc';
+
+  it('leaves attempt 0 untouched', () => {
+    expect(retryImageSrc(signed, 0)).toBe(signed);
+    expect(retryImageSrc(signed, -1)).toBe(signed);
+  });
+
+  it('appends the retry param to an already-queried URL', () => {
+    expect(retryImageSrc(signed, 2)).toBe(`${signed}&${RETRY_PARAM}=2`);
+  });
+
+  it('starts a query when the URL has none', () => {
+    expect(retryImageSrc('mpimg://cdn.example/a.webp', 1)).toBe(
+      `mpimg://cdn.example/a.webp?${RETRY_PARAM}=1`,
+    );
+  });
+
+  it('uses a query param, never a fragment — a fragment never reaches the loader', () => {
+    const out = retryImageSrc(signed, 3);
+    expect(out).not.toContain('#');
+    expect(out).toContain(`${RETRY_PARAM}=3`);
+  });
+
+  it('produces a distinct src per attempt so the resource identity changes', () => {
+    const seen = new Set([1, 2, 3].map(n => retryImageSrc(signed, n)));
+    expect(seen.size).toBe(3);
+  });
+
+  it('handles an empty base', () => {
+    expect(retryImageSrc('', 2)).toBe('');
   });
 });

--- a/reader/desktop/src/lib/readerLogic.test.ts
+++ b/reader/desktop/src/lib/readerLogic.test.ts
@@ -2,6 +2,9 @@ import { describe, it, expect } from 'vitest';
 import {
   retryImageSrc,
   RETRY_PARAM,
+  urlExpiresAt,
+  isUrlExpired,
+  expiredChapterIds,
   buildPageGroups,
   scanChapterBounds,
   chapterIdAfter,
@@ -304,5 +307,95 @@ describe('retryImageSrc', () => {
 
   it('handles an empty base', () => {
     expect(retryImageSrc('', 2)).toBe('');
+  });
+});
+
+// The real URL shape from a 2026-09-04 log capture, where every page of
+// a chapter shared expires=1788480000 (02:00 local) and the CDN answered
+// 410 Gone to every fetch after it.
+const SIGNED =
+  'https://jumpg-assets3.tokyo-cdn.com/secure/title/100004/chapter/1004422/manga_page/super_high/11.webp?hash=miIrwJMlnE7QCVfsQIs5LA&expires=1788480000';
+const EXPIRES = 1788480000;
+
+describe('urlExpiresAt', () => {
+  it('reads the expiry out of a signed CDN url', () => {
+    expect(urlExpiresAt(SIGNED)).toBe(EXPIRES);
+  });
+
+  it('returns null when there is no query at all', () => {
+    expect(urlExpiresAt('https://cdn/a/1.webp')).toBeNull();
+  });
+
+  it('returns null when expires is absent', () => {
+    expect(urlExpiresAt('https://cdn/a/1.webp?hash=abc')).toBeNull();
+  });
+
+  it('does not match a parameter that merely starts with expires', () => {
+    expect(urlExpiresAt('https://cdn/a/1.webp?expiresAt=123')).toBeNull();
+  });
+
+  it('returns null for a non-numeric or non-positive expiry', () => {
+    expect(urlExpiresAt('https://cdn/a/1.webp?expires=soon')).toBeNull();
+    expect(urlExpiresAt('https://cdn/a/1.webp?expires=0')).toBeNull();
+  });
+
+  it('finds expires regardless of position in the query', () => {
+    expect(urlExpiresAt('https://cdn/a.webp?expires=99&hash=x')).toBe(99);
+    expect(urlExpiresAt('https://cdn/a.webp?hash=x&expires=99')).toBe(99);
+  });
+});
+
+describe('isUrlExpired', () => {
+  it('is false well before the expiry', () => {
+    expect(isUrlExpired(SIGNED, (EXPIRES - 3600) * 1000)).toBe(false);
+  });
+
+  it('is true after the expiry — the 410 case from the log', () => {
+    // 07:58:47 local, ~6h past expires
+    expect(isUrlExpired(SIGNED, (EXPIRES + 6 * 3600) * 1000)).toBe(true);
+  });
+
+  it('is true just inside the skew window, before the wall-clock expiry', () => {
+    expect(isUrlExpired(SIGNED, (EXPIRES - 30) * 1000)).toBe(true);
+    expect(isUrlExpired(SIGNED, (EXPIRES - 90) * 1000)).toBe(false);
+  });
+
+  it('treats a url without expires as never expired', () => {
+    expect(isUrlExpired('https://cdn/a/1.webp?hash=abc', Date.now())).toBe(false);
+  });
+});
+
+describe('expiredChapterIds', () => {
+  const page = (chapterId: number, expires: number | null): LoadedPage => ({
+    mp: {
+      imageUrl: expires == null
+        ? 'https://cdn/a.webp?hash=x'
+        : `https://cdn/a.webp?hash=x&expires=${expires}`,
+      width: 836,
+      height: 1200,
+      encryptionKey: '',
+    } as LoadedPage['mp'],
+    chapterId,
+    chapterName: `c${chapterId}`,
+  });
+
+  it('returns each expired chapter once, in first-seen order', () => {
+    const now = (EXPIRES + 3600) * 1000;
+    const pages = [
+      page(1, EXPIRES),
+      page(1, EXPIRES),
+      page(2, EXPIRES + 86400),
+      page(3, EXPIRES),
+    ];
+    expect(expiredChapterIds(pages, now)).toEqual([1, 3]);
+  });
+
+  it('returns nothing when every url is still valid', () => {
+    const now = (EXPIRES - 3600) * 1000;
+    expect(expiredChapterIds([page(1, EXPIRES), page(2, EXPIRES)], now)).toEqual([]);
+  });
+
+  it('ignores pages whose urls carry no expiry', () => {
+    expect(expiredChapterIds([page(1, null)], Date.now())).toEqual([]);
   });
 });

--- a/reader/desktop/src/lib/readerLogic.ts
+++ b/reader/desktop/src/lib/readerLogic.ts
@@ -210,3 +210,31 @@ const KEY_MAP: Record<string, ReaderAction> = {
 export function keyToReaderAction(key: string): ReaderAction | null {
   return KEY_MAP[key] ?? null;
 }
+
+/** Query parameter used to bust a failed image load. Stripped by the
+ *  `mpimg://` scheme handler in `src-tauri/src/lib.rs` before the URL is
+ *  forwarded to the CDN, so the signed query the CDN checks is
+ *  unchanged. Keep the two in sync. */
+export const RETRY_PARAM = 'mpretry';
+
+/**
+ * Build the `<img src>` for a page, given how many reload attempts it
+ * has taken. Attempt 0 is the untouched proxied URL.
+ *
+ * This MUST be a query parameter, not a fragment. A fragment is never
+ * sent to a URL loader, so the Rust scheme handler cannot see it, and
+ * WebKit drops the fragment when computing its memory-cache key — so a
+ * fragment-only change resolves to the same already-failed resource and
+ * the load short-circuits instead of re-requesting. A query parameter
+ * changes the resource identity the loader and cache actually key on.
+ *
+ * Note that a changed src alone is still not enough to recover a broken
+ * `<img>`: WebKit also remembers the failed load on the element itself.
+ * The reader keys its `{#each}` on the attempt count so the element is
+ * recreated, which is what leaving the chapter and coming back does.
+ */
+export function retryImageSrc(base: string, attempt: number): string {
+  if (!base || attempt <= 0) return base;
+  const sep = base.includes('?') ? '&' : '?';
+  return `${base}${sep}${RETRY_PARAM}=${attempt}`;
+}

--- a/reader/desktop/src/lib/readerLogic.ts
+++ b/reader/desktop/src/lib/readerLogic.ts
@@ -238,3 +238,67 @@ export function retryImageSrc(base: string, attempt: number): string {
   const sep = base.includes('?') ? '&' : '?';
   return `${base}${sep}${RETRY_PARAM}=${attempt}`;
 }
+
+/** Query parameter carrying the signed URL's hard expiry, in unix
+ *  seconds. MANGA Plus CDN URLs are signed *and* time-limited — once
+ *  `expires` passes, the CDN answers 410 Gone and no amount of retrying
+ *  the same URL will ever succeed. Fresh URLs come only from another
+ *  `get_chapter_pages` call. */
+export const EXPIRES_PARAM = 'expires';
+
+/**
+ * Read the expiry (unix seconds) out of a signed CDN URL, or null when
+ * the URL carries no usable `expires`. Parsed by hand rather than with
+ * `URL` so this stays pure and works on the `mpimg://` form too.
+ */
+export function urlExpiresAt(url: string): number | null {
+  const q = url.indexOf('?');
+  if (q < 0) return null;
+  for (const part of url.slice(q + 1).split('&')) {
+    const eq = part.indexOf('=');
+    if (eq < 0) continue;
+    if (part.slice(0, eq) !== EXPIRES_PARAM) continue;
+    const n = Number(part.slice(eq + 1));
+    return Number.isFinite(n) && n > 0 ? n : null;
+  }
+  return null;
+}
+
+/**
+ * True when a signed CDN URL is past its expiry, or close enough that a
+ * fetch started now would likely lose the race.
+ *
+ * `skewSeconds` covers both clock drift against the CDN and the gap
+ * between deciding to load and the request actually landing. A URL with
+ * no `expires` is never considered expired — we can't know, and treating
+ * it as dead would break any unsigned/cached URL.
+ */
+export function isUrlExpired(url: string, nowMs = Date.now(), skewSeconds = 60): boolean {
+  const exp = urlExpiresAt(url);
+  if (exp == null) return false;
+  return exp - skewSeconds <= Math.floor(nowMs / 1000);
+}
+
+/**
+ * Chapter ids whose loaded page URLs have expired, in first-seen order.
+ *
+ * Used on resume: after the laptop wakes, every URL the reader is
+ * holding may be dead at once, and refreshing per-chapter is far cheaper
+ * than letting each `<img>` discover its own 410.
+ */
+export function expiredChapterIds(
+  pages: LoadedPage[],
+  nowMs = Date.now(),
+  skewSeconds = 60,
+): number[] {
+  const out: number[] = [];
+  const seen = new Set<number>();
+  for (const p of pages) {
+    if (seen.has(p.chapterId)) continue;
+    if (isUrlExpired(p.mp.imageUrl, nowMs, skewSeconds)) {
+      seen.add(p.chapterId);
+      out.push(p.chapterId);
+    }
+  }
+  return out;
+}

--- a/reader/desktop/src/routes/reader/[chapterId]/+page.svelte
+++ b/reader/desktop/src/routes/reader/[chapterId]/+page.svelte
@@ -30,6 +30,7 @@
     findGroupContainingPage,
     firstGroupOfChapter,
     keyToReaderAction,
+    retryImageSrc,
     type LoadedPage,
     type PageGroup,
   } from '$lib/readerLogic';
@@ -201,12 +202,17 @@
   const imageRetryTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
   function imageSrc(url: string): string {
-    const base = proxied(url);
-    const n = imageAttempts.get(url) ?? 0;
-    // Fragments don't reach the server — the mpimg custom protocol
-    // handler in lib.rs strips them — but they change what the browser
-    // sees as the src, forcing a fresh request.
-    return n > 0 ? `${base}#attempt=${n}` : base;
+    return retryImageSrc(proxied(url), imageAttempts.get(url) ?? 0);
+  }
+
+  // Retry identity for the {#each} key. Bumping the attempt count
+  // changes the key, so Svelte destroys and recreates the <img> rather
+  // than patching its src. That matters: WebKit records a failed load
+  // against the element itself, so a patched src on a broken <img> can
+  // be ignored. Recreating the element is what leaving the chapter and
+  // re-entering does — the one recovery path known to work.
+  function imageKey(url: string): string {
+    return `${url}|${imageAttempts.get(url) ?? 0}`;
   }
 
   function onImageError(url: string) {
@@ -1030,13 +1036,15 @@
             data-group-index={gi}
             bind:this={frameEls[gi]}
           >
-            {#each group.pages as lp, pi (lp.mp.imageUrl)}
+            {#each group.pages as lp, pi (imageKey(lp.mp.imageUrl))}
               <!--
                 width + height attrs reserve the correct aspect-ratio'd
                 space before bytes arrive (prevents Cumulative Layout
                 Shift). onerror/onload track per-image fetch outcome so
                 we can surface a retry overlay; the imageSrc helper
-                appends a fragment when retrying so the browser refetches.
+                appends a cache-busting query param when retrying (see
+                readerLogic.retryImageSrc) and the each-key above forces
+                a fresh element so the refetch actually happens.
                 Fallback to typical MANGA Plus page dimensions (836x1200)
                 when the proto returned zeroes — otherwise the wrapper
                 collapses and the placeholder is invisible until bytes

--- a/reader/desktop/src/routes/reader/[chapterId]/+page.svelte
+++ b/reader/desktop/src/routes/reader/[chapterId]/+page.svelte
@@ -31,6 +31,8 @@
     firstGroupOfChapter,
     keyToReaderAction,
     retryImageSrc,
+    isUrlExpired,
+    expiredChapterIds,
     type LoadedPage,
     type PageGroup,
   } from '$lib/readerLogic';
@@ -216,6 +218,15 @@
   }
 
   function onImageError(url: string) {
+    // An expired signed URL is permanently dead (410 Gone). Spending the
+    // retry budget on it accomplishes nothing; only fresh URLs help.
+    if (isUrlExpired(url)) {
+      const owner = chapterIdForImage(url);
+      if (owner != null) {
+        void refreshChapterPages(owner);
+        return;
+      }
+    }
     const attempts = imageAttempts.get(url) ?? 0;
     if (attempts >= MAX_AUTO_RETRIES) {
       // Auto-retry budget exhausted. Show the manual hatch.
@@ -251,6 +262,15 @@
   }
 
   function retryImage(url: string) {
+    // Same as the auto path: a dead URL needs re-signing, not another
+    // request. This is the button the user pressed that "did nothing".
+    if (isUrlExpired(url)) {
+      const owner = chapterIdForImage(url);
+      if (owner != null) {
+        void refreshChapterPages(owner);
+        return;
+      }
+    }
     // Manual retry beyond the auto-budget — bump attempts and clear
     // failure so the overlay disappears while the new fetch is in
     // flight. If THIS attempt fails too, onImageError sees attempts
@@ -263,6 +283,81 @@
     }
     imageAttempts = new Map(imageAttempts).set(url, attempts);
     failedImageUrls = setWithoutStr(failedImageUrls, url);
+  }
+
+  // Chapters currently being re-signed. A screenful of simultaneously
+  // expired <img> elements would otherwise fire a dozen identical
+  // get_chapter_pages calls.
+  const refreshingChapterIds = new Set<number>();
+
+  /** The chapter that owns a page URL, or null once it has been replaced. */
+  function chapterIdForImage(url: string): number | null {
+    return loadedPages.find(lp => lp.mp.imageUrl === url)?.chapterId ?? null;
+  }
+
+  /**
+   * Replace a chapter's page URLs in place with freshly signed ones.
+   *
+   * MANGA Plus CDN URLs carry a hard `expires`; once it passes the CDN
+   * answers 410 Gone, and retrying the same URL can never succeed no
+   * matter how correct the retry plumbing is. This is why leaving the
+   * chapter and re-entering was the only recovery anyone ever found —
+   * that path calls get_chapter_pages, which mints new URLs. Do the same
+   * thing here, without losing scroll position.
+   */
+  async function refreshChapterPages(chapterId: number) {
+    if (refreshingChapterIds.has(chapterId)) return;
+    refreshingChapterIds.add(chapterId);
+    try {
+      const res = await fetchChapter(chapterId);
+      if (!res.ok) {
+        console.warn(`[reader] URL refresh for chapter ${chapterId} failed:`, res.error);
+        return;
+      }
+      const fresh = (res.viewer.pages ?? [])
+        .map(p => p.data?.mangaPage)
+        .filter((mp): mp is MangaPage => !!mp);
+      if (fresh.length === 0) return;
+
+      // Positional swap: the CDN re-signs the same pages in the same
+      // order, so page N of the refetch is page N of what we hold. A
+      // short response leaves the tail untouched rather than truncating.
+      let i = 0;
+      const staleUrls: string[] = [];
+      loadedPages = loadedPages.map(lp => {
+        if (lp.chapterId !== chapterId) return lp;
+        const next = fresh[i++];
+        if (!next) return lp;
+        staleUrls.push(lp.mp.imageUrl);
+        return { ...lp, mp: next };
+      });
+      if (staleUrls.length === 0) return;
+
+      // The new URLs must start from a clean slate — inheriting an
+      // exhausted retry budget would leave them stuck behind the same
+      // overlay the dead URLs were.
+      const attempts = new Map(imageAttempts);
+      const failed = new Set(failedImageUrls);
+      for (const url of staleUrls) {
+        const timer = imageRetryTimers.get(url);
+        if (timer) clearTimeout(timer);
+        imageRetryTimers.delete(url);
+        attempts.delete(url);
+        failed.delete(url);
+      }
+      imageAttempts = attempts;
+      failedImageUrls = failed;
+    } finally {
+      refreshingChapterIds.delete(chapterId);
+    }
+  }
+
+  // After a lid close the entire stack of signed URLs can be dead at
+  // once. Refresh when the window comes back rather than making every
+  // lazy <img> discover its own 410 one at a time.
+  function onVisibilityChange() {
+    if (document.visibilityState !== 'visible') return;
+    for (const id of expiredChapterIds(loadedPages)) void refreshChapterPages(id);
   }
 
   function reloadAllImages() {
@@ -394,12 +489,14 @@
     eyeFilter = getEyeFilter();
     window.addEventListener('keydown', onKey);
     window.addEventListener('mousemove', onBarMouseMove);
+    document.addEventListener('visibilitychange', onVisibilityChange);
     // Bars start visible so the user can orient, then collapse.
     scheduleBarHide('top');
     scheduleBarHide('bottom');
     return () => {
       window.removeEventListener('keydown', onKey);
       window.removeEventListener('mousemove', onBarMouseMove);
+      document.removeEventListener('visibilitychange', onVisibilityChange);
       observer?.disconnect();
     };
   });

--- a/reader/desktop/src/routes/reader/[chapterId]/+page.svelte
+++ b/reader/desktop/src/routes/reader/[chapterId]/+page.svelte
@@ -384,6 +384,26 @@
     return out;
   }
 
+  // Absolute index in loadedPages -> 1-based page number within its own
+  // chapter. The reload overlay has to agree with the progress bar,
+  // which counts per chapter (pageInChapter); labelling the overlay with
+  // the absolute index made it announce "Reload page 63" while the bar
+  // read "Page 18 of 45" as soon as the reader had scrolled past a
+  // chapter boundary. Built in one pass rather than calling
+  // scanChapterBounds per rendered group, which would be quadratic.
+  let pageNumberInChapter: number[] = $derived.by(() => {
+    const out = new Array<number>(loadedPages.length);
+    let n = 0;
+    let prev: number | null = null;
+    for (let i = 0; i < loadedPages.length; i++) {
+      const cid = loadedPages[i].chapterId;
+      n = cid === prev ? n + 1 : 1;
+      prev = cid;
+      out[i] = n;
+    }
+    return out;
+  });
+
   // Pages bundled into render frames. See lib/readerLogic.ts for the
   // pure grouping logic + its unit tests.
   let pageGroups: PageGroup[] = $derived(buildPageGroups(loadedPages, pageMode));
@@ -1150,7 +1170,7 @@
               <div class="page-image-wrapper">
                 <img
                   src={imageSrc(lp.mp.imageUrl)}
-                  alt="Page {group.firstPageIndex + pi + 1}"
+                  alt="Page {pageNumberInChapter[group.firstPageIndex + pi] ?? group.firstPageIndex + pi + 1}"
                   width={lp.mp.width || 836}
                   height={lp.mp.height || 1200}
                   loading={group.firstPageIndex + pi < 3 ? 'eager' : 'lazy'}
@@ -1164,10 +1184,10 @@
                   <button
                     class="image-retry-btn"
                     type="button"
-                    aria-label="Retry loading page {group.firstPageIndex + pi + 1}"
+                    aria-label="Retry loading page {pageNumberInChapter[group.firstPageIndex + pi] ?? group.firstPageIndex + pi + 1}"
                     onclick={(e) => { e.stopPropagation(); retryImage(lp.mp.imageUrl); }}
                   >
-                    ↻ Reload page {group.firstPageIndex + pi + 1}
+                    ↻ Reload page {pageNumberInChapter[group.firstPageIndex + pi] ?? group.firstPageIndex + pi + 1}
                   </button>
                 {/if}
               </div>


### PR DESCRIPTION
## Problem

When a page image fails to load, the reader tints the slot red and offers a `↻ Reload page N` button. The button never works. The only recovery is to leave the chapter and re-enter it.

## Root cause

The user's own observation pins it down:

- Leaving and re-entering **works**, which means the bytes are obtainable — `fetch_image` has a disk-cache fast path that returns before any network call.
- The retry **never** works, so it was not reaching that code path at all.
- The only difference between the two: re-entering destroys and recreates the `<img>` elements. The retry only mutated the existing element's `src`.

And the mutation it made was fragment-only:

```js
return n > 0 ? `${base}#attempt=${n}` : base;
```

A fragment is never sent to a URL loader, so the `mpimg://` scheme handler could not see it, and WebKit drops the fragment when computing its memory-cache key. The "new" src therefore resolved to the same already-failed resource and the load short-circuited. The comment above that line claimed the handler stripped the fragment before forwarding to the CDN — no such code existed, which suggests the mechanism was never verified end to end.

Compounding it, the `{#each}` was keyed on `lp.mp.imageUrl`, stable across retries, so Svelte patched the broken element rather than replacing it. WebKit also records a failed load against the element itself.

## Fix

`retryImageSrc()` appends a `?mpretry=N` **query** parameter, which changes the identity the loader and cache actually key on, and the each-key includes the attempt count so the element is recreated — which is exactly what leaving and re-entering the chapter does.

Since the CDN validates a signed query, `strip_retry_param()` removes the parameter in the scheme handler before the URL leaves the process. The outgoing URL is byte-for-byte what it was before.

## Also: HTTP timeouts

The reported trigger is closing the laptop lid, which exposed a second defect. The reqwest client was built with no timeouts at all — no request, connect, or pool-idle timeout.

After a suspend, pooled TCP connections are dead but the local kernel does not know, so reusing one writes a request into a socket that never answers, and it hangs until the OS TCP timeout (~15 min). That is worse than a slow load: a hung image fetch holds an `image_gate` permit the whole time, and once all permits are parked every later fetch blocks before it can start, including the user's retry. A hang is also not an error, so `fetch_image`'s retry loop never runs.

Adds `pool_idle_timeout` (30s), which targets resume directly — after a suspend every pooled connection is long-idle and gets discarded rather than reused — plus connect (15s) and request (60s) ceilings, generous enough for a large page on a slow link.

## Tests

New coverage for both halves: `retryImageSrc` (query not fragment, distinct src per attempt, no-query and empty-base edges) and `strip_retry_param` (removes only the exact key, leaves signed params and a `mpretryx=9` lookalike intact).

`bun run test` 83 passed · `bun run check` 0 errors · `cargo test` 13 + 8 + 63 passed · clippy clean with `-D warnings` on both crates.

## Note

I could not reproduce a suspend/resume cycle to confirm end to end; this fixes the mechanism the evidence points at. If a red page ever survives this, the next thing to capture is `[mpimg] fetch failed` on stderr, which would indicate an expired `plus_vw_token` — a different problem that only a fresh `manga_viewer_v3` call can fix.
