### PR TITLE
docs: iOS secret walkthrough, release-build gotcha, and mise deprecation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@
 - Rust clippy commands from `reader`: `cargo clippy -p mangaplus-api --lib --tests -- -D warnings` and `cargo clippy -p mangaplus-desktop --lib --tests -- -D warnings`.
 - `cargo fmt --check` is warn-only in CI because no committed rustfmt config exists yet.
 - Local full-ish verification from `reader`: `./verify.sh`; it also probes Vite dev CSS chunks that `bun run build` can miss.
+- Release binary from `reader/desktop`: `bun run tauri build --no-bundle` (drop the flag to also produce deb/rpm/AppImage).
 - No frontend lint script/config was found; do not invent `bun run lint`.
 
 ## Build/test prerequisites
@@ -38,3 +39,4 @@
 - The full-catalog SWR cache (`all_titles_<lang>_<clang>.bin` + `.meta.json` in the cache dir) defaults to a 24h TTL; `MANGAPLUS_CATALOG_TTL_HOURS=N` overrides it.
 - Linux render mode is decided before WebKit starts: `MANGAPLUS_RENDER_MODE` wins, then `~/.config/mangaplus-reader/render.conf`, then crash-recovery marker, then GPU/display auto-detect. See `docs/troubleshooting.md` before changing this path.
 - For UI/Svelte route changes, run a dev-server check or `./verify.sh`; production build alone may not catch style-chunk extraction failures.
+- Build release binaries with `bun run tauri build --no-bundle`, never bare `cargo build --release`. Only the Tauri CLI sets the env its codegen reads, so a plain cargo release build silently embeds `devUrl` (`http://localhost:1420`) instead of `frontendDist` — the binary compiles and runs, then fails to connect at launch unless `bun run dev` happens to be up. Check a suspect binary with `strings target/release/mangaplus-desktop | grep -c _app/immutable`: nonzero means the frontend is embedded, 0 means it is not.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
     ·
     <a href="docs/install.md">Install guide</a>
     ·
-    <a href="docs/android-secret.md">Get your secret</a>
+    Get your secret: <a href="docs/android-secret.md">Android</a> / <a href="docs/ios-secret.md">iOS</a>
     ·
     <a href="docs/troubleshooting.md">Troubleshooting</a>
     ·
@@ -75,7 +75,7 @@ Just a downloaded binary. Launch it, and the app registers itself with the offic
 If you also want subscription-locked chapters on desktop:
 
 - An active MANGA Plus subscription on a phone install.
-- Your `deviceSecret` from that install. 5 minutes if your phone is rooted (`adb shell`), about 20 if it isn't (rooted Android emulator on your desktop — walkthrough in [docs/android-secret.md](docs/android-secret.md)).
+- Your `deviceSecret` from that install. 5 minutes if your phone is rooted (`adb shell`), about 20 if it isn't (rooted Android emulator on your desktop — walkthrough in [docs/android-secret.md](docs/android-secret.md)). On iPhone you read it off the wire with mitmproxy instead — [docs/ios-secret.md](docs/ios-secret.md).
 - Paste it into the app's settings. Replaces the free-tier session with your subscriber one.
 
 ## Install
@@ -137,6 +137,7 @@ If you don't trust a random binary on the internet to do that honestly (you shou
 
 - [`docs/install.md`](docs/install.md): end-user install. Free-tier auto-register and the optional subscriber upgrade.
 - [`docs/android-secret.md`](docs/android-secret.md): the rooted-AVD walkthrough for extracting a subscriber `deviceSecret`. Doesn't touch your phone.
+- [`docs/ios-secret.md`](docs/ios-secret.md): the same secret on iOS, read off the wire with mitmproxy.
 - [`docs/troubleshooting.md`](docs/troubleshooting.md): blank screen on Linux, render-mode overrides, WebKitGTK crash workarounds, and how the auto-recovery handles all of that for you.
 - [`docs/debugging.md`](docs/debugging.md): contributor notes. mitmproxy, Frida, the real headers, what tripped me up.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -48,7 +48,7 @@ That's the whole flow if you only want free content. Skip the rest of this page.
 
 If you pay for MANGA Plus on a phone and want the subscription-locked chapters on desktop too, you need to replace the free-tier `deviceSecret` with your existing subscriber one. The subscriber secret lives in your phone install — there's no way to migrate the subscription itself, just the token it's tied to.
 
-Extract from your phone. Path depends on whether it's rooted.
+Extract from your phone. On Android the path depends on whether it's rooted; on iOS you read the secret off the wire instead.
 
 **Rooted phone (Magisk):**
 
@@ -69,6 +69,10 @@ That value is what you need.
 Set up a rooted Android emulator on your desktop. About 20 minutes the first time, never again. Full walkthrough in [docs/android-secret.md](android-secret.md). Rough shape: Android Studio + Play Store image, root it with [rootAVD](https://github.com/newbit1/rootAVD), sign into Google Play with your subscription account, install MANGA Plus from the Play Store, then the `adb shell` command above.
 
 This is what I use. It doesn't touch the daily phone.
+
+**iPhone (iOS):**
+
+There's no rooting equivalent, so you proxy the app instead: point the phone at mitmproxy on your desktop, trust its CA, open any chapter, and pull `secret=` out of the request query string. Full walkthrough in [docs/ios-secret.md](ios-secret.md). Same 32-hex-char value the Android path produces.
 
 **Paste it into the app:**
 

--- a/docs/ios-secret.md
+++ b/docs/ios-secret.md
@@ -1,0 +1,6 @@
+# Extract your `deviceSecret` (iOS, via mitmproxy)
+
+1. Run mitmproxy on your desktop: mitmproxy --listen-port 8080
+2. On the iPhone: Wi-Fi → your network → Configure Proxy → Manual → your desktop's LAN IP, port 8080.
+3. Visit <http://mitm.it> in Safari on the phone, download the iOS cert profile, then install it: Settings → General → VPN & Device Management. Then the step people miss — Settings → General → About → Certificate Trust Settings → toggle full trust on for the mitmproxy CA.
+4. Open MANGA Plus, load any chapter, and filter mitmproxy for jumpg-webapi (or whatever cfg.host is set to). Pull secret= out of the query string — 32 hex chars, same shape as the Android one.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -112,7 +112,7 @@ The marker is just a file. If you ever want to force the next launch into `safe`
 
 ## "I can read free chapters but my subscription content is locked"
 
-The auto-registered free-tier secret only has access to free content. See [`docs/install.md`](install.md) for the subscriber path: extract your phone's `deviceSecret` and paste it into the in-app dialog. Detailed walkthrough in [`docs/android-secret.md`](android-secret.md).
+The auto-registered free-tier secret only has access to free content. See [`docs/install.md`](install.md) for the subscriber path: extract your phone's `deviceSecret` and paste it into the in-app dialog. Detailed walkthrough in [`docs/android-secret.md`](android-secret.md), or [`docs/ios-secret.md`](ios-secret.md) if your subscription lives on an iPhone.
 
 ---
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,6 @@
-[tools]
-python = "system"
+# Keep this project on the system Python rather than a mise-managed one.
+# Previously expressed as `[tools] python = "system"`; the "@system"
+# version was deprecated in favour of disabling the tool outright
+# (the env-var form is MISE_DISABLE_TOOLS=python).
+[settings]
+disable_tools = ["python"]


### PR DESCRIPTION
Four small non-code changes, each one something a contributor or subscriber currently hits.

## `AGENTS.md`: bare `cargo build --release` produces a broken binary

Only the Tauri CLI sets the environment its codegen reads. A plain `cargo build --release` therefore embeds `devUrl` (`http://localhost:1420`) instead of `frontendDist` — the binary compiles, links and launches, then fails to connect unless a dev server happens to be running.

Nothing at build time flags this: it exits 0, and the bad binary is only ~115 KB smaller. I lost time to it before working out what had happened. Documents `bun run tauri build --no-bundle` as the working command, plus the check that distinguishes a good binary from a bad one:

```
strings target/release/mangaplus-desktop | grep -c _app/immutable
```

Nonzero means the frontend is embedded; 0 means it is not.

## `mise.toml`: drop the deprecated `@system` pin

Every `mise` invocation in the repo directory currently prints:

```
mise WARN deprecated [system_tool_version]: @system is deprecated, use MISE_DISABLE_TOOLS instead
```

Switches `[tools] python = "system"` to the config-file equivalent, `[settings] disable_tools = ["python"]`, preserving the intent of 49957ff. Verified: no warning in the repo root, `reader/`, or `reader/desktop/`, and `python3` still resolves to the system interpreter.

## `docs/ios-secret.md`: the iOS extraction path

`docs/android-secret.md` covers rooted phones and the rooted-AVD route, but there was nothing for a subscriber whose subscription lives on an iPhone. There is no rooting equivalent there, so the procedure is to proxy the app through mitmproxy and read `secret=` off the request query string — same 32-hex-char value the Android path yields.

## Link it from the entry points

`README.md`, `docs/install.md` and `docs/troubleshooting.md` all presented secret extraction as Android-only. `install.md` §3 in particular framed the choice as depending "on whether it's rooted", which is the Android axis alone — reworded to separate platform from root state, so the new iOS subsection sits under an accurate sentence.

All relative links in the touched files verified to resolve.
